### PR TITLE
Publish a rosbag from cmd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,9 @@ find_package(ament_cmake_ros REQUIRED)
 
 find_package(point_cloud_transport REQUIRED)
 find_package(point_cloud_transport_plugins REQUIRED)
-find_package(rclcpp REQUIRED) 
-find_package(rosbag2_cpp REQUIRED) 
+find_package(rclcpp REQUIRED)
+find_package(rcpputils REQUIRED)
+find_package(rosbag2_cpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
 include_directories(
@@ -30,7 +31,7 @@ ament_target_dependencies(encoder_test point_cloud_transport rosbag2_cpp sensor_
 
 # publisher
 add_executable(publisher_test src/my_publisher.cpp)
-ament_target_dependencies(publisher_test point_cloud_transport rclcpp rosbag2_cpp sensor_msgs)
+ament_target_dependencies(publisher_test point_cloud_transport rclcpp rcpputils rosbag2_cpp sensor_msgs)
 
 # subscriber
 add_executable(subscriber_test src/my_subscriber.cpp)

--- a/package.xml
+++ b/package.xml
@@ -15,11 +15,14 @@
 
   <build_depend>point_cloud_transport</build_depend>
   <build_depend>rclcpp</build_depend>
+  <build_depend>rcpputils</build_depend>
   <build_depend>rosbag2_cpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
   <exec_depend>point_cloud_transport_plugins</exec_depend>
   <exec_depend>point_cloud_transport</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rcpputils</exec_depend>
   <exec_depend>rosbag2_cpp</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
 

--- a/src/my_publisher.cpp
+++ b/src/my_publisher.cpp
@@ -32,20 +32,15 @@ int main(int argc, char ** argv)
     "point_cloud_transport_tutorial");
   std::string bag_file = shared_directory + "/resources/rosbag2_2023_08_05-16_08_51";
 
+  if (argc > 1)
+  {
+    bag_file = argv[1];
+  }
+
   if (!rcpputils::fs::exists(bag_file))
   {
-    std::cout << "Not able to open file 1 [" << bag_file << "]" << '\n';
+    std::cout << "Not able to open file [" << bag_file << "]" << '\n';
     return -1;
-  } else {
-    if (argc > 1)
-    {
-      bag_file = argv[1];
-      if (!rcpputils::fs::exists(bag_file))
-      {
-        std::cout << "Not able to open file [" << bag_file << "]" << '\n';
-        return -1;
-      }
-    }
   }
 
   std::cout << "Reading [" << bag_file << "] bagfile" << '\n';

--- a/src/my_publisher.cpp
+++ b/src/my_publisher.cpp
@@ -6,10 +6,13 @@
 
 #include <point_cloud_transport/point_cloud_transport.hpp>
 
+#include <iostream>
+
 // for reading rosbag
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <rclcpp/serialization.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <rcpputils/filesystem_helper.hpp>
 #include <rosbag2_cpp/reader.hpp>
 #include <rosbag2_cpp/storage_options.hpp>
 #include <rosbag2_cpp/converter_interfaces/serialization_format_converter.hpp>
@@ -27,7 +30,25 @@ int main(int argc, char ** argv)
   const std::string bagged_cloud_topic = "/point_cloud";
   const std::string shared_directory = ament_index_cpp::get_package_share_directory(
     "point_cloud_transport_tutorial");
-  const std::string bag_file = shared_directory + "/resources/rosbag2_2023_08_05-16_08_51";
+  std::string bag_file = shared_directory + "/resources/rosbag2_2023_08_05-16_08_51";
+
+  if (!rcpputils::fs::exists(bag_file))
+  {
+    std::cout << "Not able to open file 1 [" << bag_file << "]" << '\n';
+    return -1;
+  } else {
+    if (argc > 1)
+    {
+      bag_file = argv[1];
+      if (!rcpputils::fs::exists(bag_file))
+      {
+        std::cout << "Not able to open file [" << bag_file << "]" << '\n';
+        return -1;
+      }
+    }
+  }
+
+  std::cout << "Reading [" << bag_file << "] bagfile" << '\n';
 
   // boiler-plate to tell rosbag2 how to read our bag
   rosbag2_storage::StorageOptions storage_options;


### PR DESCRIPTION
Added the option to choose a rosbag from command line.

If we release this package the rosbag will be compressed and it's not possible to republicate the data but with these changes at least we can select a rosbag from cmd