### PR TITLE
point_cloud_transport_plugins does not need to be in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ endif()
 find_package(ament_cmake_ros REQUIRED)
 
 find_package(point_cloud_transport REQUIRED)
-find_package(point_cloud_transport_plugins REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rosbag2_cpp REQUIRED)


### PR DESCRIPTION
See here: https://github.com/ros-perception/point_cloud_transport/issues/42

The package does not need point_cloud_transport_plugins to be in the cmake file as it is not a build dependency. This seemed to be causing the CI to fail since it was not finding the package at the build phase. (which is still odd though because the package should have been installed)

Before:
Rpr__point_cloud_transport_tutorial__ubuntu_jammy_amd64 Failed ❌ 

After:
Rpr__point_cloud_transport_tutorial__ubuntu_jammy_amd64 Passes ✅ 